### PR TITLE
Limit @query modifications to IssueQuery instances

### DIFF
--- a/lib/query_share/patches/queries_controller_patch.rb
+++ b/lib/query_share/patches/queries_controller_patch.rb
@@ -18,17 +18,18 @@ module QueryShare
       module InstanceMethods
         def update_query_from_params_with_share
           update_query_from_params_without_share
-          share_visibility = params[:query] && params[:query][:visibility]
+          if @query.instanceof?(IssueQuery)
+            share_visibility = params[:query] && params[:query][:visibility]
 
-          if (User.current.allowed_to?(:manage_group_queries, @query.project) || User.current.admin?) &&
-           share_visibility.to_i == IssueQuery::VISIBILITY_GROUP
-            @query.query_principal_ids = params[:query] && params[:query][:principal_ids]
-            @query.principals_logins = params[:query] && params[:query][:principals_logins]
-            @query.visibility = share_visibility
-          elsif @query.visibility.to_i == IssueQuery::VISIBILITY_GROUP
-            @query.visibility = IssueQuery::VISIBILITY_PRIVATE
+            if (User.current.allowed_to?(:manage_group_queries, @query.project) || User.current.admin?) &&
+             share_visibility.to_i == IssueQuery::VISIBILITY_GROUP
+              @query.query_principal_ids = params[:query] && params[:query][:principal_ids]
+              @query.principals_logins = params[:query] && params[:query][:principals_logins]
+              @query.visibility = share_visibility
+            elsif @query.visibility.to_i == IssueQuery::VISIBILITY_GROUP
+              @query.visibility = IssueQuery::VISIBILITY_PRIVATE
+            end
           end
-
           @query
         end
       end


### PR DESCRIPTION
Only IssueQuery implements the used functions, thus the plugin breaks any other implementations creating subclasses of Query and QueriesController.